### PR TITLE
refactor: update logger export to ES module syntax

### DIFF
--- a/backend/src/utils/logger.js
+++ b/backend/src/utils/logger.js
@@ -13,7 +13,7 @@ const logFormat = format.combine(
     })
 );
 
-const logger = createLogger({
+export const logger = createLogger({
     level: 'info',
     format: logFormat,
     transports: [
@@ -60,5 +60,3 @@ import fs from 'fs';
 if(!fs.existsSync('logs')){
     fs.mkdirSync('logs', {recursive: true});
 }
-
-module.exports = logger;


### PR DESCRIPTION
This PR refactors the logger utility by changing its export style 
from CommonJS (`module.exports`) to ES module (`export const logger`). 
This improves consistency across the backend codebase and aligns 
with modern JavaScript module standards.
