### PR TITLE
chore(utils): migrate to ES module syntax and refine logger

### DIFF
--- a/backend/src/utils/jwt.utils.js
+++ b/backend/src/utils/jwt.utils.js
@@ -1,4 +1,4 @@
-const jwt = require("jsonwebtoken")
+import jwt from "jsonwebtoken";
 
 export const generateJwtToken = (user) => {
     const jwtToken = jwt.sign({userId: user._id, role: user.role}, process.env.JWT_TOKEN, {

--- a/backend/src/utils/logger.js
+++ b/backend/src/utils/logger.js
@@ -1,5 +1,5 @@
-const {createLogger, format, transports} = require("winston")
-const DailyRotateFile = require("winston-daily-rotate-file")
+import {createLogger, format, transports} from "winston"
+import DailyRotateFile from "winston-daily-rotate-file"
 
 
 const logFormat = format.combine(
@@ -53,10 +53,13 @@ export const logger = createLogger({
     ],
     rejectionHandlers: [
         new transports.File({filename: 'logs/rejections.log'})
-    ]
+    ],
+    exitOnError: false
 });
 
 import fs from 'fs';
 if(!fs.existsSync('logs')){
     fs.mkdirSync('logs', {recursive: true});
 }
+
+

--- a/backend/src/utils/password.utils.js
+++ b/backend/src/utils/password.utils.js
@@ -1,4 +1,4 @@
-const bcrypt = require("bcrypt")
+import bcrypt from "bcrypt";
 
 export const hashPassword = async (password) => {
     const salt = await bcrypt.genSalt(10);


### PR DESCRIPTION
Converted all files in the utils folder to use ES module import/export syntax.

Applied small improvements in logger for consistency and maintainability.

Why?
Aligns the codebase with modern JavaScript module standards, enabling tree-shaking, better tooling support, and a consistent import/export pattern.